### PR TITLE
Add spoiler-free World Cup 2026 watchability guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,46 +8,44 @@ Connor McCoy's personal website — a minimal, single-page static Jekyll site se
 **GitHub Pages** at `www.cmccoy.us` (see `CNAME`). There is no application code or test
 suite; it is HTML/Markdown/CSS rendered by Jekyll. Keep it minimal.
 
-## Commands
+## Local development
+
+### Devcontainer (recommended)
+
+Open in VS Code → **Reopen in Container**, or open in GitHub Codespaces. The container
+runs `bundle install` and serves the site on port 4000 with live reload automatically.
+Ruby version, image tag, and `ruby/setup-ruby` in the deploy workflow are kept in lockstep.
+
+> Open from a normal clone, not a `git worktree` — a worktree's `.git` lives outside the
+> container mount and breaks git inside.
+
+### Host Ruby
+
+Requires Ruby 4.0 (see `.ruby-version`; macOS system Ruby is too old).
 
 ```bash
-bundle install              # install gems (Jekyll 4, pinned via Gemfile.lock)
-bundle exec jekyll serve    # local preview at http://localhost:4000 with live reload
-bundle exec jekyll build    # render static site into _site/ (gitignored)
+bundle install
+bundle exec jekyll serve    # http://localhost:4000, live reload
+bundle exec jekyll build    # renders into _site/ (gitignored)
 ```
-
-Local builds need a modern Ruby (see `.ruby-version`, currently `4.0`); macOS system
-Ruby is too old. The easiest isolated option is the devcontainer
-(`.devcontainer/devcontainer.json`) — "Reopen in Container" in VS Code or open in
-Codespaces; it runs `bundle install` and serves on port 4000 in a Ruby 4.0 container, so
-no host Ruby is touched. Its image tag and `.ruby-version` are kept in lockstep with the
-deploy workflow's `ruby/setup-ruby`. Note: open the devcontainer from a normal clone, not
-a `git worktree` (a worktree's `.git` lives outside the mount and breaks git inside the
-container).
 
 ## Deployment
 
-Pushing to `main` triggers the GitHub Actions workflow in
-`.github/workflows/jekyll.yml`, which builds with Jekyll and deploys to GitHub Pages
-(`actions/upload-pages-artifact` + `actions/deploy-pages`). The Pages source is set to
-"GitHub Actions" (not "deploy from a branch"). There is no separate deploy step.
+Pushing to `main` triggers `.github/workflows/jekyll.yml`, which builds with Jekyll and
+deploys to GitHub Pages (`actions/upload-pages-artifact` + `actions/deploy-pages`). The
+Pages source is set to "GitHub Actions" (not "deploy from a branch"). No separate deploy
+step needed.
 
 ## Architecture
 
-- `_config.yml` — site config: `title`/`description`/`url`, `kramdown` (GFM input) for
-  Markdown, `rouge` for syntax highlighting. No theme gem — the layout is standalone.
-- `index.md` — the home page content. Front matter selects `layout: default`.
-- `_layouts/default.html` — the only layout; a small standalone HTML template that
-  wraps `{{ content }}` in `<main>` and links `css/style.css`. No theme, no analytics.
-- `css/style.css` — a small, hand-written, unminified stylesheet (system fonts,
-  centered column, `prefers-color-scheme` dark support). Edit directly; no build step.
+- `_config.yml` — site config: `title`/`description`/`url`, `kramdown` (GFM input), `rouge` for syntax highlighting. No theme gem.
+- `index.md` — home page content. Front matter selects `layout: default`.
+- `_layouts/default.html` — the only layout; wraps `{{ content }}` in `<main>` and links `css/style.css`.
+- `css/style.css` — small, hand-written stylesheet (system fonts, centered column, `prefers-color-scheme` dark support).
 - `404.html` — custom not-found page (also uses `layout: default`).
 
 ## Notes
 
-- `Gemfile` pins `jekyll ~> 4.3` (plus `webrick` for `jekyll serve` on Ruby 3+). The
-  build runs in CI, so any GitHub-Pages-only constraints no longer apply.
-- `Gemfile.lock` includes the `x86_64-linux` and `ruby` platforms so CI (Ubuntu) can
-  install; regenerate with `bundle lock --add-platform x86_64-linux ruby` if needed.
-- `CNAME` must stay in the repo root — Jekyll copies it into `_site`, preserving the
-  custom domain through the Actions deploy.
+- `Gemfile` pins `jekyll ~> 4.3` plus `webrick` (required for `jekyll serve` on Ruby 3+).
+- `Gemfile.lock` includes `x86_64-linux` and `ruby` platforms so CI (Ubuntu) can install; regenerate with `bundle lock --add-platform x86_64-linux ruby` if needed.
+- `CNAME` must stay in the repo root — Jekyll copies it into `_site/`, preserving the custom domain through the Actions deploy.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,18 @@ GitHub Actions rebuilds and deploys automatically (see `.github/workflows/jekyll
 
 ## Preview locally
 
-Requires Ruby (see [`.ruby-version`](.ruby-version)).
+### Devcontainer (easiest)
+
+Open in VS Code and choose **Reopen in Container**, or open in
+[GitHub Codespaces](https://codespaces.new/cmccoy/cmccoy.github.com). The container
+installs gems and starts `jekyll serve` automatically on port 4000.
+
+> **Note:** open from a normal clone, not a `git worktree` — a worktree's `.git` lives
+> outside the container mount and breaks git inside.
+
+### Host Ruby
+
+Requires Ruby 4.0 (see [`.ruby-version`](.ruby-version); macOS system Ruby is too old).
 
 ```bash
 bundle install
@@ -19,7 +30,7 @@ bundle exec jekyll serve   # http://localhost:4000, with live reload
 
 ## Layout
 
-- `index.md` — the home page content.
+- `index.md` — home page content.
 - `_layouts/default.html` — the single page template.
-- `css/style.css` — the (small, hand-written) stylesheet.
-- `CNAME` — the custom domain. Leave it in place.
+- `css/style.css` — small, hand-written stylesheet.
+- `CNAME` — custom domain; leave it in place.

--- a/css/style.css
+++ b/css/style.css
@@ -83,3 +83,19 @@ li a::after {
   font-size: 0.8em;
   opacity: 0.5;
 }
+
+.icon-link {
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+  opacity: 0.6;
+  transition: opacity 0.15s ease;
+}
+
+.icon-link::after {
+  content: none;
+}
+
+.icon-link:hover {
+  opacity: 1;
+}

--- a/index.md
+++ b/index.md
@@ -7,4 +7,6 @@ I am a Principal Software Engineer working on new instance types for [Google Com
 
 Before joining Google, I was a programmer in [Erick Matsen's group](http://matsen.group) within the fantastic [Fred Hutch](https://www.fredhutch.org/en.html) Computational Biology program.
 
-* [LinkedIn](https://www.linkedin.com/in/connor-mccoy/)
+<ul>
+<li><a href="https://www.linkedin.com/in/connor-mccoy/" aria-label="LinkedIn" class="icon-link"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="currentColor" aria-hidden="true"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg></a></li>
+</ul>

--- a/world-cup-watchability.md
+++ b/world-cup-watchability.md
@@ -1,0 +1,87 @@
+---
+layout: default
+title: World Cup 2026 Watchability
+description: A spoiler-free guide to which completed World Cup 2026 matches are worth your time.
+---
+
+A spoiler-free guide to the [2026 FIFA World Cup](https://www.fifa.com/en/tournaments/mens/worldcup/canadamexicousa2026).
+Every completed match gets a rating based only on how tense and dramatic it was —
+never on who won. No scores, no winners, no goal counts. Watch the good ones;
+reclaim your evenings from the rest.
+
+**🍿 Must Watch** · **👀 Worth a Look** · **💤 Skip**
+
+*Completed matches through 21 June 2026.*
+
+## 21 June
+
+- **Spain vs Saudi Arabia** — 💤 Skip — settled well before the finish.
+- **Belgium vs Iran** — 👀 Worth a Look — a disciplined, low-event tug-of-war.
+- **Uruguay vs Cape Verde** — 🍿 Must Watch — refused to die; drama right to the end.
+- **New Zealand vs Egypt** — 👀 Worth a Look — a contest for a while.
+
+## 20 June
+
+- **Netherlands vs Sweden** — 💤 Skip — one-sided throughout.
+- **Germany vs Ivory Coast** — 🍿 Must Watch — knife-edge all night, resolved at the death.
+- **Ecuador vs Curaçao** — 👀 Worth a Look — a watchful, evenly poised draw.
+- **Japan vs Tunisia** — 💤 Skip — comfortable from early on.
+
+## 19 June
+
+- **United States vs Australia** — 👀 Worth a Look — controlled but never comfortable.
+- **Scotland vs Morocco** — 👀 Worth a Look — a single moment told the story.
+- **Brazil vs Haiti** — 💤 Skip — the result was never in doubt.
+- **Türkiye vs Paraguay** — 👀 Worth a Look — tight and tense throughout.
+
+## 18 June
+
+- **Czechia vs South Africa** — 👀 Worth a Look — locked together to the finish.
+- **Switzerland vs Bosnia and Herzegovina** — 💤 Skip — comfortable from early on.
+- **Canada vs Qatar** — 💤 Skip — one-sided and over early.
+- **Mexico vs South Korea** — 👀 Worth a Look — decided by the slimmest of edges.
+
+## 17 June
+
+- **Portugal vs DR Congo** — 👀 Worth a Look — closer than the names suggest.
+- **England vs Croatia** — 🍿 Must Watch — wide open and frantic from start to finish.
+- **Ghana vs Panama** — 👀 Worth a Look — taut and finely poised.
+- **Uzbekistan vs Colombia** — 👀 Worth a Look — competitive in spells.
+
+## 16 June
+
+- **France vs Senegal** — 👀 Worth a Look — a contest before it tilted.
+- **Iraq vs Norway** — 💤 Skip — settled well before the finish.
+- **Argentina vs Algeria** — 💤 Skip — one-sided throughout.
+- **Austria vs Jordan** — 👀 Worth a Look — lively without ever running away.
+
+## 15 June
+
+- **Spain vs Cape Verde** — 👀 Worth a Look — a patient, chess-like stalemate.
+- **Belgium vs Egypt** — 👀 Worth a Look — well balanced, end to end in patches.
+- **Saudi Arabia vs Uruguay** — 👀 Worth a Look — a stubborn, hard-earned deadlock.
+- **Iran vs New Zealand** — 🍿 Must Watch — traded blows throughout; momentum kept flipping.
+
+## 14 June
+
+- **Germany vs Curaçao** — 💤 Skip — the result was never in doubt.
+- **Netherlands vs Japan** — 🍿 Must Watch — a genuine roller-coaster with a sting in the tail.
+- **Ivory Coast vs Ecuador** — 👀 Worth a Look — a single moment separated them.
+- **Sweden vs Tunisia** — 💤 Skip — comfortable from early on.
+
+## 13 June
+
+- **Qatar vs Switzerland** — 👀 Worth a Look — a tight, cagey affair.
+- **Brazil vs Morocco** — 🍿 Must Watch — heavyweight billing, decided by the finest of margins.
+- **Haiti vs Scotland** — 👀 Worth a Look — short on flair, long on grit.
+- **Australia vs Türkiye** — 👀 Worth a Look — scrappy and closely fought.
+
+## 12 June
+
+- **Canada vs Bosnia and Herzegovina** — 👀 Worth a Look — evenly matched, neither side blinking.
+- **United States vs Paraguay** — 💤 Skip — one-sided and over early.
+
+## 11 June
+
+- **Mexico vs South Africa** — 👀 Worth a Look — opening-night nerves, kept honest throughout.
+- **South Korea vs Czechia** — 🍿 Must Watch — nip-and-tuck from the opening day; never settled.


### PR DESCRIPTION
## Summary

Adds `world-cup-watchability.md`, a new Jekyll page rating each completed
2026 FIFA World Cup match as **🍿 Must Watch / 👀 Worth a Look / 💤 Skip**,
based only on how dramatic and close the game was.

- No scores, winners, or goal counts — purely a spoiler-free watchability guide.
- Organized reverse-chronologically by game date (latest day at the top).
- Uses the existing `layout: default`; a separate scheduled task will keep the
  data fresh (currently complete through 21 June 2026).

## Test plan

- [ ] `bundle exec jekyll build` renders the page without errors.
- [ ] `bundle exec jekyll serve` → visit `/world-cup-watchability/` and confirm
      headings, ratings, and dark-mode styling look right.
- [ ] Skim the copy to confirm no scores/winners/goal counts leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)