### PR TITLE
World Cup page: descending sort, weekday headers, nowrap teams, /wcw alias

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -269,6 +269,12 @@ li a::after {
   font-weight: 450;
 }
 
+/* Keep each side's flag and name on one line; wrapping may still happen
+   between the two sides (around "vs"). */
+.wc-side {
+  white-space: nowrap;
+}
+
 .wc-flag {
   font-style: normal;
   /* Keep the flag glyph tight against its team name. */

--- a/js/world-cup.js
+++ b/js/world-cup.js
@@ -40,6 +40,16 @@ if (dataEl && mount) {
     day: "numeric",
     timeZone: "America/Los_Angeles",
   });
+  // Weekday for the day heading, in the same Pacific zone the days are grouped
+  // by, so e.g. "22 June" renders as "Monday, 22 June".
+  const ptWeekdayFmt = new Intl.DateTimeFormat([], {
+    weekday: "long",
+    timeZone: "America/Los_Angeles",
+  });
+  const dayHeading = (day) => {
+    const k = day.matches.map((m) => m.kickoff).find(Boolean);
+    return k ? `${ptWeekdayFmt.format(new Date(k))}, ${day.date}` : day.date;
+  };
 
   // Short label for the viewer's zone (e.g. "PDT", "GMT+9"), derived from a
   // real kickoff so it reflects that date's DST state.
@@ -92,8 +102,8 @@ if (dataEl && mount) {
                 active.has(m.rating) &&
                 (needle === "" || m.teams.toLowerCase().includes(needle)),
             )
-            // Earliest kickoff first within each day.
-            .sort((a, b) => (Date.parse(a.kickoff) || 0) - (Date.parse(b.kickoff) || 0)),
+            // Latest kickoff first within each day.
+            .sort((a, b) => (Date.parse(b.kickoff) || 0) - (Date.parse(a.kickoff) || 0)),
         }))
         .filter((day) => day.matches.length > 0);
     }, [active, needle]);
@@ -133,7 +143,7 @@ if (dataEl && mount) {
         : days.map(
             (day) => html`
               <section class="wc-day" key=${day.date}>
-                <h2>${day.date}</h2>
+                <h2>${dayHeading(day)}</h2>
                 <table class="wc-table">
                   <thead>
                     <tr>
@@ -157,10 +167,13 @@ if (dataEl && mount) {
                           <td class="wc-teams">
                             ${sidesOf(m.teams).map(
                               (s, i) => html`${i > 0 ? " vs " : ""}<span
-                                  class="wc-flag"
-                                  aria-hidden="true"
-                                  >${s.flag}</span
-                                > ${s.name}`,
+                                  class="wc-side"
+                                  ><span
+                                    class="wc-flag"
+                                    aria-hidden="true"
+                                    >${s.flag}</span
+                                  > ${s.name}</span
+                                >`,
                             )}
                           </td>
                           <td class="wc-note">${m.note}</td>

--- a/wcw.html
+++ b/wcw.html
@@ -1,0 +1,20 @@
+---
+# Short alias for the World Cup guide. The canonical page stays at
+# /world-cup-watchability.html (already shared publicly); this just redirects.
+permalink: /wcw/
+sitemap: false
+---
+{% assign target = "/world-cup-watchability.html" | relative_url %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Redirecting…</title>
+<link rel="canonical" href="{{ "/world-cup-watchability.html" | absolute_url }}">
+<meta http-equiv="refresh" content="0; url={{ target }}">
+<meta name="robots" content="noindex">
+</head>
+<body>
+<p>Redirecting to the <a href="{{ target }}">World Cup 2026 Watchability guide</a>.</p>
+</body>
+</html>

--- a/world-cup-watchability.md
+++ b/world-cup-watchability.md
@@ -20,11 +20,11 @@ reclaim your evenings from the rest.
 </p>
 {% for day in site.data.world_cup.days %}
 <section class="wc-day">
-<h2>{{ day.date }}</h2>
+{% comment %} Weekday is derived from a kickoff in this day, rendered in the site's Pacific timezone (the same zone the days are grouped by) via the epoch round-trip. {% endcomment %}{% assign day_epoch = day.matches[0].kickoff | date: "%s" %}<h2>{{ day_epoch | date: "%A" }}, {{ day.date }}</h2>
 <table class="wc-table">
 <thead><tr><th scope="col" class="wc-col-rating">Rating</th><th scope="col" class="wc-col-time">Time (PT)</th><th scope="col">Match</th><th scope="col">Note</th></tr></thead>
 <tbody>
-{% comment %} Matches are authored in kickoff order within each day. Pacific time is derived from the absolute `kickoff` instant: format to epoch seconds (UTC) first, then re-format so Time.at renders it in the site's configured timezone. {% endcomment %}{% for m in day.matches %}{% assign r = site.data.world_cup.ratings[m.rating] %}{% assign sides = m.teams | split: " vs " %}{% assign epoch = m.kickoff | date: "%s" %}<tr class="wc-match"><td class="wc-rating" title="{{ r.label }}">{{ r.emoji }}</td><td class="wc-time">{{ epoch | date: "%-I:%M %p" }}</td><td class="wc-teams">{% for s in sides %}{% unless forloop.first %} vs {% endunless %}<span class="wc-flag" aria-hidden="true">{{ site.data.world_cup.flags[s] }}</span> {{ s }}{% endfor %}</td><td class="wc-note">{{ m.note }}</td></tr>
+{% comment %} Matches are authored in ascending kickoff order; `reversed` shows them latest-first within the day. Pacific time is derived from the absolute `kickoff` instant: format to epoch seconds (UTC) first, then re-format so Time.at renders it in the site's configured timezone. {% endcomment %}{% for m in day.matches reversed %}{% assign r = site.data.world_cup.ratings[m.rating] %}{% assign sides = m.teams | split: " vs " %}{% assign epoch = m.kickoff | date: "%s" %}<tr class="wc-match"><td class="wc-rating" title="{{ r.label }}">{{ r.emoji }}</td><td class="wc-time">{{ epoch | date: "%-I:%M %p" }}</td><td class="wc-teams">{% for s in sides %}{% unless forloop.first %} vs {% endunless %}<span class="wc-side"><span class="wc-flag" aria-hidden="true">{{ site.data.world_cup.flags[s] }}</span> {{ s }}</span>{% endfor %}</td><td class="wc-note">{{ m.note }}</td></tr>
 {% endfor %}</tbody>
 </table>
 </section>


### PR DESCRIPTION
Four small changes to the World Cup watchability page:

1. **Sort descending by time** — matches within each day now show latest kickoff first (JS sort + `reversed` in the Liquid fallback).
2. **Weekday in date headers** — headers now read e.g. "Monday, 22 June", derived in Pacific time (the zone the days are grouped by) in both the JS app and the no-JS fallback.
3. **Keep flag + name together** — each side is wrapped in `.wc-side { white-space: nowrap }` so a flag never splits from its country name across a line break; wrapping can still happen around "vs".
4. **`/wcw` short alias** — new `wcw.html` redirects to the canonical `/world-cup-watchability.html` (which has already been shared publicly). Pure Jekyll, no plugin: meta-refresh + `rel=canonical` + `noindex`, with a plain link fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)