### PR TITLE
Switch devcontainer to Ubuntu + mise for Ruby LSP

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,9 +1,0 @@
-{
-  "features": {
-    "ghcr.io/devcontainers-contrib/features/mise:1": {
-      "version": "1.0.0",
-      "resolved": "ghcr.io/devcontainers-extra/features/mise@sha256:5c389ab1e3c8e44e5e0ff119f6868d54dbb781bc860bd8587dc66209cb8c4a8c",
-      "integrity": "sha256:5c389ab1e3c8e44e5e0ff119f6868d54dbb781bc860bd8587dc66209cb8c4a8c"
-    }
-  }
-}

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers-contrib/features/mise:1": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/devcontainers-extra/features/mise@sha256:5c389ab1e3c8e44e5e0ff119f6868d54dbb781bc860bd8587dc66209cb8c4a8c",
+      "integrity": "sha256:5c389ab1e3c8e44e5e0ff119f6868d54dbb781bc860bd8587dc66209cb8c4a8c"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,10 @@
 {
   "name": "cmccoy.github.com (Jekyll)",
-  // Ruby 4.0 — kept in lockstep with .ruby-version and the deploy workflow (ruby/setup-ruby)
-  "image": "mcr.microsoft.com/devcontainers/ruby:4.0",
+
+  // Generic Ubuntu base. Tools are installed below rather than via a feature, because the
+  // community mise feature installs to /usr/local/bin/mise but Ruby LSP only searches
+  // ~/.local/bin/mise — they don't agree on the path.
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
 
   // 4000 = `jekyll serve`, 35729 = LiveReload
   "forwardPorts": [4000, 35729],
@@ -9,15 +12,23 @@
     "4000": { "label": "Jekyll site", "onAutoForward": "openPreview" }
   },
 
-  // Install gems inside the container (isolated from the host Ruby/gemset)
-  "postCreateCommand": "bundle install",
+  // 1. Install mise to ~/.local/bin/mise (the path Ruby LSP searches).
+  // 2. mise install reads .ruby-version and installs the matching Ruby.
+  // 3. bundle install fetches gems into the container.
+  // mise exec -- injects mise's environment (Ruby shims on PATH) without requiring the shell
+  // to have sourced the mise activation script. Needed because postCreateCommand and
+  // postAttachCommand run in a plain /bin/sh with no ~/.bashrc sourced.
+  "postCreateCommand": "curl https://mise.run | sh && ~/.local/bin/mise trust && ~/.local/bin/mise install && ~/.local/bin/mise exec -- bundle install",
 
   // Auto-serve the site with live reload when you attach. Remove if you'd rather start it manually.
-  "postAttachCommand": "bundle exec jekyll serve --host 0.0.0.0 --livereload",
+  "postAttachCommand": "~/.local/bin/mise exec -- bundle exec jekyll serve --host 0.0.0.0 --livereload",
 
   "customizations": {
     "vscode": {
-      "extensions": ["Shopify.ruby-lsp"]
+      "extensions": ["Shopify.ruby-lsp"],
+      "settings": {
+        "rubyLsp.rubyVersionManager.identifier": "mise"
+      }
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Ruby version, image tag, and `ruby/setup-ruby` in the deploy workflow are kept i
 
 ### Host Ruby
 
-Requires Ruby 4.0 (see `.ruby-version`; macOS system Ruby is too old).
+Requires Ruby 4.0 (see `.ruby-version`; macOS system Ruby is too old). Install via `mise` (`mise install`) or Homebrew (`brew install ruby`).
 
 ```bash
 bundle install

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,5 @@
+[tools]
+ruby = "4.0"
+
+[settings.ruby]
+compile = false


### PR DESCRIPTION
## Summary

- Replaces the `mcr.microsoft.com/devcontainers/ruby:4.0` image with a plain Ubuntu base and a manual `curl https://mise.run | sh` install.
- The community mise devcontainer feature installs to `/usr/local/bin/mise`, but Ruby LSP only searches `~/.local/bin/mise` — they disagree on the path and LSP silently fails to start. Installing mise manually to `~/.local/bin/mise` fixes this.
- Adds `mise.toml` pinning Ruby 4.0 (with `compile = false` to skip building from source).
- Sets `rubyLsp.rubyVersionManager.identifier: "mise"` so the extension finds the right manager.
- `postAttachCommand` now prefixes with `~/.local/bin/mise exec --` so the shell doesn't need to have sourced mise's activation script.

## Test plan

- [ ] Open in GitHub Codespaces (or VS Code → Reopen in Container) and confirm `bundle install` completes during `postCreateCommand`
- [ ] Verify Jekyll auto-starts on attach and the site is reachable at port 4000
- [ ] Open any `.rb` file and confirm Ruby LSP activates (no "Ruby version manager not found" error in the output panel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)