### PR TITLE
Fix aside note firing on cloud.google.com links

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -9,7 +9,7 @@ const html = htm.bind(h);
 // URL fragment → aside text. Matched with href.includes(key).
 const ASIDES = {
   "anthropic.com": "makes Claude.",
-  "google.com":    "search company, founded 1998.",
+  "//www.google.com": "search company, founded 1998.",
 };
 
 function findAside(href) {


### PR DESCRIPTION
## Summary

- The `google.com` substring key in `ASIDES` matched `cloud.google.com` URLs, so hovering the Google Compute Engine and TPU links incorrectly showed the "search company, founded 1998." aside
- Fix: narrow the key to `//www.google.com` so only the plain Google homepage link matches

## Test plan

- Hover the "Google" link → aside appears
- Hover "Google Compute Engine" and "TPUs" → no aside
- Hover "Anthropic" → aside still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)