### PR TITLE
Add interactive PR previews via gh-pages branch

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -5,19 +5,20 @@ on:
     branches: [main]
   workflow_dispatch:
 
-# Allow the workflow to deploy to GitHub Pages.
+# Build on main and publish the rendered site to the gh-pages branch. Pages is
+# served from that branch (Settings → Pages → "Deploy from a branch" → gh-pages),
+# which lets PR previews live alongside production under /pr-preview/ on the same
+# branch — see pr-preview.yml.
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
-# Allow one concurrent deployment; don't cancel an in-progress run.
+# Don't cancel an in-progress production deploy.
 concurrency:
-  group: pages
+  group: deploy-production
   cancel-in-progress: false
 
 jobs:
-  build:
+  build-deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -25,20 +26,15 @@ jobs:
         with:
           ruby-version: '.ruby-version'
           bundler-cache: true
-      - id: pages
-        uses: actions/configure-pages@v6
       - name: Build with Jekyll
-        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        # Custom domain serves from the root, so the default empty baseurl is correct.
+        run: bundle exec jekyll build
         env:
           JEKYLL_ENV: production
-      - uses: actions/upload-pages-artifact@v5
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - id: deployment
-        uses: actions/deploy-pages@v5
+      - name: Deploy to gh-pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: _site
+          branch: gh-pages
+          # Keep PR preview directories when redeploying production.
+          clean-exclude: pr-preview/

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,42 @@
+name: Deploy PR preview
+
+# Build each pull request and publish an interactive preview reviewers can click
+# through, at https://www.cmccoy.us/pr-preview/pr-<N>/. The preview is deployed
+# into a pr-preview/ subdirectory of the gh-pages branch (shared with production,
+# which preserves it via clean-exclude) and removed automatically when the PR
+# closes. A sticky comment on the PR links to the preview.
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+# Serialise repeated pushes to the same PR; the latest commit wins.
+concurrency:
+  group: preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write       # push the preview to the gh-pages branch
+      pull-requests: write   # post/update the sticky preview comment
+    steps:
+      - uses: actions/checkout@v6
+        if: github.event.action != 'closed'
+      - uses: ruby/setup-ruby@v1
+        if: github.event.action != 'closed'
+        with:
+          ruby-version: '.ruby-version'
+          bundler-cache: true
+      - name: Build with Jekyll
+        if: github.event.action != 'closed'
+        # baseurl must match the subdirectory the preview is served from so that
+        # relative_url-based asset links resolve correctly.
+        run: bundle exec jekyll build --baseurl "/pr-preview/pr-${{ github.event.number }}"
+        env:
+          JEKYLL_ENV: production
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: _site
+          pages-base-url: www.cmccoy.us

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,9 +32,30 @@ bundle exec jekyll build    # renders into _site/ (gitignored)
 ## Deployment
 
 Pushing to `main` triggers `.github/workflows/jekyll.yml`, which builds with Jekyll and
-deploys to GitHub Pages (`actions/upload-pages-artifact` + `actions/deploy-pages`). The
-Pages source is set to "GitHub Actions" (not "deploy from a branch"). No separate deploy
-step needed.
+publishes the rendered `_site/` to the **`gh-pages` branch** (via
+`JamesIves/github-pages-deploy-action`). GitHub Pages serves that branch, so the Pages
+source must be set to **Settings → Pages → "Deploy from a branch" → `gh-pages` / `(root)`**.
+The build writes `CNAME` into the published output, preserving the custom domain.
+
+### PR previews
+
+`.github/workflows/pr-preview.yml` builds every pull request and deploys an interactive,
+clickable preview to `https://www.cmccoy.us/pr-preview/pr-<N>/` (via
+`rossjrw/pr-preview-action`). The preview lives in a `pr-preview/` subdirectory of the
+same `gh-pages` branch — production deploys preserve it with `clean-exclude: pr-preview/`,
+and it is removed automatically when the PR closes. A sticky comment on the PR links to
+the preview.
+
+Previews are built with `--baseurl /pr-preview/pr-<N>`, so all asset links must go through
+Liquid's `relative_url` / `absolute_url` filters (not hardcoded absolute paths) to resolve
+under the subdirectory. One known limitation: absolute asset paths *inside* static JS that
+Jekyll doesn't process — e.g. the `/assets/seuss-flower-*.png` references in
+`js/seuss-flower.js` — are not rewritten, so on a preview they load from the production
+domain rather than the preview. Harmless for unchanged assets; a PR that changes those
+specific images won't show the change in its preview.
+
+> Previews only deploy for PRs from this repo (branches), not forks — `GITHUB_TOKEN` is
+> read-only for fork PRs, which is expected for a single-maintainer site.
 
 ## Architecture
 
@@ -75,4 +96,4 @@ To update a vendored library (the host CDNs may be blocked in sandboxes, so pull
 
 - `Gemfile` pins `jekyll ~> 4.3` plus `webrick` (required for `jekyll serve` on Ruby 3+).
 - `Gemfile.lock` includes `x86_64-linux` and `ruby` platforms so CI (Ubuntu) can install; regenerate with `bundle lock --add-platform x86_64-linux ruby` if needed.
-- `CNAME` must stay in the repo root — Jekyll copies it into `_site/`, preserving the custom domain through the Actions deploy.
+- `CNAME` must stay in the repo root — Jekyll copies it into `_site/`, which is published to the `gh-pages` branch, preserving the custom domain.

--- a/index.md
+++ b/index.md
@@ -17,5 +17,5 @@ Outside of work, I am married to the amazing [Cate](https://www.benaroyaresearch
 </ul>
 
 <div id="seuss-flower-root"></div>
-<script type="module" src="/js/seuss-flower.js"></script>
-<script type="module" src="/js/index.js"></script>
+<script type="module" src="{{ '/js/seuss-flower.js' | relative_url }}"></script>
+<script type="module" src="{{ '/js/index.js' | relative_url }}"></script>


### PR DESCRIPTION
## What

Sets up infrastructure so reviewers can click through a **live, interactive preview** of any PR that changes the site, at `https://www.cmccoy.us/pr-preview/pr-<N>/`, with a sticky comment on the PR linking to it. The preview is removed automatically when the PR closes.

## Why this shape

Interactive previews on GitHub Pages require the Pages **source to be a branch** — a repo has exactly one Pages source, so previews and production must share a hosting mechanism. This moves production off the "GitHub Actions" Pages source and onto a `gh-pages` branch, then deploys previews into a `pr-preview/` subdirectory of that same branch. Fully self-hosted — no external services, accounts, or secrets, in keeping with the repo's minimal/self-contained philosophy.

## Changes

- **`.github/workflows/jekyll.yml`** — production now builds on `main` and publishes `_site/` to the `gh-pages` branch via `JamesIves/github-pages-deploy-action`, preserving PR previews with `clean-exclude: pr-preview/`. `CNAME` is carried into the published output, so the custom domain is preserved.
- **`.github/workflows/pr-preview.yml`** (new) — builds each PR with `--baseurl /pr-preview/pr-<N>` and deploys via `rossjrw/pr-preview-action`.
- **`index.md`** — fixed two hardcoded absolute `/js/` script paths to use `relative_url` so they resolve under the preview subpath. (Verified locally: prod build keeps `/js/...`, preview build emits `/pr-preview/pr-1/js/...`.)
- **`CLAUDE.md`** — documents the new deploy flow, the one-time Pages setting, and a known caveat about absolute asset paths inside static JS.

## ⚠️ One required manual step

After merge, change **Settings → Pages → Build and deployment → Source** to **"Deploy from a branch" → `gh-pages` / `(root)`**. Until then, production keeps serving the last "GitHub Actions" deploy (it won't break, just won't update) and preview URLs will 404. Merging this triggers the production workflow, which creates the `gh-pages` branch so the setting is ready to flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DstwP2knezUiaBVqpBSZgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01DstwP2knezUiaBVqpBSZgR)_