### PR TITLE
PR previews on the modern GitHub Actions Pages source

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -3,38 +3,64 @@ name: Build and deploy site
 on:
   push:
     branches: [main]
+  # Redeploy whenever a PR preview is added/updated/removed, so the preview
+  # appears in the live Pages artifact (see pr-preview.yml).
+  workflow_run:
+    workflows: ["Deploy PR preview"]
+    types: [completed]
   workflow_dispatch:
 
-# Build on main and publish the rendered site to the gh-pages branch. Pages is
-# served from that branch (Settings → Pages → "Deploy from a branch" → gh-pages),
-# which lets PR previews live alongside production under /pr-preview/ on the same
-# branch — see pr-preview.yml.
+# Deploy to the GitHub Pages "GitHub Actions" source (no branch source).
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 
-# Don't cancel an in-progress production deploy.
+# One deployment at a time; queue rather than cancel so no deploy is lost.
 concurrency:
-  group: deploy-production
+  group: pages
   cancel-in-progress: false
 
 jobs:
-  build-deploy:
+  build:
     runs-on: ubuntu-latest
+    # Don't redeploy if the upstream preview workflow failed.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:
+      # Always builds production from the default branch (main) — for push and
+      # workflow_run events alike — so PR code never reaches the production paths.
       - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '.ruby-version'
           bundler-cache: true
+      - id: pages
+        uses: actions/configure-pages@v6
       - name: Build with Jekyll
-        # Custom domain serves from the root, so the default empty baseurl is correct.
-        run: bundle exec jekyll build
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
-      - name: Deploy to gh-pages
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: _site
-          branch: gh-pages
-          # Keep PR preview directories when redeploying production.
-          clean-exclude: pr-preview/
+      - name: Overlay PR previews into the site
+        # PR previews are kept on the (unserved) pr-previews branch under
+        # pr-preview/pr-<N>/. Fold them into the artifact so they ship at
+        # https://www.cmccoy.us/pr-preview/pr-<N>/ alongside production.
+        run: |
+          if git fetch origin pr-previews 2>/dev/null && git cat-file -e FETCH_HEAD:pr-preview 2>/dev/null; then
+            git checkout FETCH_HEAD -- pr-preview
+            mkdir -p _site/pr-preview
+            cp -r pr-preview/. _site/pr-preview/
+            echo "Overlaid PR previews from the pr-previews branch."
+          else
+            echo "No PR previews to overlay."
+          fi
+      - uses: actions/upload-pages-artifact@v5
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,10 +1,11 @@
 name: Deploy PR preview
 
-# Build each pull request and publish an interactive preview reviewers can click
-# through, at https://www.cmccoy.us/pr-preview/pr-<N>/. The preview is deployed
-# into a pr-preview/ subdirectory of the gh-pages branch (shared with production,
-# which preserves it via clean-exclude) and removed automatically when the PR
-# closes. A sticky comment on the PR links to the preview.
+# Build each pull request and stage an interactive, clickable preview reviewers
+# can use at https://www.cmccoy.us/pr-preview/pr-<N>/. The built preview is stored
+# on the (unserved) pr-previews branch under pr-preview/pr-<N>/ and removed when the
+# PR closes; the deploy workflow folds that directory into the live Pages artifact,
+# so production stays on the modern "GitHub Actions" Pages source with no branch
+# source or manual settings change. A sticky comment on the PR links to the preview.
 on:
   pull_request:
     types: [opened, reopened, synchronize, closed]
@@ -18,7 +19,7 @@ jobs:
   preview:
     runs-on: ubuntu-latest
     permissions:
-      contents: write       # push the preview to the gh-pages branch
+      contents: write       # commit the preview to the pr-previews store branch
       pull-requests: write   # post/update the sticky preview comment
     steps:
       - uses: actions/checkout@v6
@@ -35,8 +36,13 @@ jobs:
         run: bundle exec jekyll build --baseurl "/pr-preview/pr-${{ github.event.number }}"
         env:
           JEKYLL_ENV: production
-      - name: Deploy preview
+      - name: Stage preview on the pr-previews branch
+        # Deploys on opened/synchronize, removes on closed. The preview-branch is a
+        # storage branch only — it is NOT the Pages source; the deploy workflow
+        # serves its contents from the production artifact.
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: _site
+          preview-branch: pr-previews
+          umbrella-dir: pr-preview
           pages-base-url: www.cmccoy.us

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,21 +32,38 @@ bundle exec jekyll build    # renders into _site/ (gitignored)
 ## Deployment
 
 Pushing to `main` triggers `.github/workflows/jekyll.yml`, which builds with Jekyll and
-publishes the rendered `_site/` to the **`gh-pages` branch** (via
-`JamesIves/github-pages-deploy-action`). GitHub Pages serves that branch, so the Pages
-source must be set to **Settings → Pages → "Deploy from a branch" → `gh-pages` / `(root)`**.
-The build writes `CNAME` into the published output, preserving the custom domain.
+deploys to GitHub Pages via the modern **"GitHub Actions" Pages source**
+(`actions/configure-pages` → `actions/upload-pages-artifact` → `actions/deploy-pages`).
+No branch source and no manual Pages setting — the Pages source stays on **Settings →
+Pages → "GitHub Actions"**. `CNAME` (in the repo root) is copied into `_site/`, preserving
+the custom domain.
 
 ### PR previews
 
-`.github/workflows/pr-preview.yml` builds every pull request and deploys an interactive,
-clickable preview to `https://www.cmccoy.us/pr-preview/pr-<N>/` (via
-`rossjrw/pr-preview-action`). The preview lives in a `pr-preview/` subdirectory of the
-same `gh-pages` branch — production deploys preserve it with `clean-exclude: pr-preview/`,
-and it is removed automatically when the PR closes. A sticky comment on the PR links to
-the preview.
+`.github/workflows/pr-preview.yml` builds every pull request with
+`--baseurl /pr-preview/pr-<N>` and stages an interactive, clickable preview reviewers can
+use at `https://www.cmccoy.us/pr-preview/pr-<N>/`. A sticky comment on the PR links to it.
 
-Previews are built with `--baseurl /pr-preview/pr-<N>`, so all asset links must go through
+Because the "GitHub Actions" Pages source serves a single whole-site artifact (each deploy
+replaces the entire site), previews can't be a separate deployment — they have to ship
+*inside* the same artifact. So the flow is:
+
+1. `pr-preview.yml` builds the PR and uses `rossjrw/pr-preview-action` to commit the built
+   site to the **`pr-previews` branch** under `pr-preview/pr-<N>/`. **This branch is storage
+   only — it is never the Pages source and is never served directly.** On PR close the
+   action removes that directory (and the sticky comment).
+2. When `pr-preview.yml` finishes, it triggers `jekyll.yml` via `workflow_run`. That deploy
+   job rebuilds production *from `main`* (so PR code never reaches production paths), then
+   its "Overlay PR previews" step folds the `pr-preview/` tree from the `pr-previews` branch
+   into `_site/pr-preview/` before uploading the artifact. Pushes to `main` redeploy the
+   same way, so previews for still-open PRs are preserved on every production deploy.
+
+A single concurrency group (`pages`) serialises all deploys so none clobber each other.
+Tradeoff of staying on the Actions source: every preview add/update/remove triggers a full
+production redeploy (cheap for this site), and a freshly pushed preview goes live a beat
+after its sticky comment posts (once the `workflow_run` deploy completes).
+
+Previews are built with the `/pr-preview/pr-<N>` baseurl, so all asset links must go through
 Liquid's `relative_url` / `absolute_url` filters (not hardcoded absolute paths) to resolve
 under the subdirectory. One known limitation: absolute asset paths *inside* static JS that
 Jekyll doesn't process — e.g. the `/assets/seuss-flower-*.png` references in
@@ -96,4 +113,4 @@ To update a vendored library (the host CDNs may be blocked in sandboxes, so pull
 
 - `Gemfile` pins `jekyll ~> 4.3` plus `webrick` (required for `jekyll serve` on Ruby 3+).
 - `Gemfile.lock` includes `x86_64-linux` and `ruby` platforms so CI (Ubuntu) can install; regenerate with `bundle lock --add-platform x86_64-linux ruby` if needed.
-- `CNAME` must stay in the repo root — Jekyll copies it into `_site/`, which is published to the `gh-pages` branch, preserving the custom domain.
+- `CNAME` must stay in the repo root — Jekyll copies it into `_site/`, which is deployed to GitHub Pages, preserving the custom domain.


### PR DESCRIPTION
## What

Reworks the PR-preview setup so **production stays on the modern "GitHub Actions" Pages source** (`actions/deploy-pages`) — no branch source, and **no manual Settings → Pages change required**. Reviewers still get an interactive, clickable preview of each PR at `https://www.cmccoy.us/pr-preview/pr-<N>/` with a sticky comment linking to it.

This supersedes the earlier gh-pages-branch approach (#46).

## How it works

The Actions source serves one whole-site artifact (each deploy replaces the entire site), so previews are **baked into that artifact** rather than served as a separate deployment:

1. **`pr-preview.yml`** builds each PR with `--baseurl /pr-preview/pr-<N>` and uses `rossjrw/pr-preview-action` to stage the build on a dedicated **`pr-previews` branch** under `pr-preview/pr-<N>/`. That branch is **storage only — never the Pages source, never served directly.** On PR close it removes the directory and the sticky comment.
2. When `pr-preview.yml` finishes it triggers **`jekyll.yml`** via `workflow_run`. The deploy job always builds production **from `main`** (so PR code never reaches production paths), then its *Overlay PR previews* step folds the `pr-preview/` tree from the `pr-previews` branch into `_site/pr-preview/` before uploading the artifact via `actions/upload-pages-artifact` + `actions/deploy-pages`. Pushes to `main` redeploy the same way, so open PRs' previews survive every production deploy.

A single `pages` concurrency group serialises deploys so none clobber each other.

## Tradeoff

Staying on the Actions source means every preview add/update/remove triggers a full production redeploy (cheap for this site), and a freshly pushed preview goes live a beat after its sticky comment posts (once the `workflow_run` deploy completes).

## Verified locally

- Both workflow YAMLs parse.
- Production build keeps root-relative asset paths (`/js/...`); preview build emits `/pr-preview/pr-1/js/...`.
- `CNAME` lands in `_site/`.
- Overlay `cp` nests correctly as `_site/pr-preview/pr-<N>/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DstwP2knezUiaBVqpBSZgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01DstwP2knezUiaBVqpBSZgR)_